### PR TITLE
Added catch error for stocks that doesn't exist or can't be found

### DIFF
--- a/DiscordPy/bot.py
+++ b/DiscordPy/bot.py
@@ -12,12 +12,16 @@ bot = commands.Bot(command_prefix='$')
 
 @bot.command(name = 'stonk')
 async def nine_nine(ctx, *arg):
-    if(len(arg) == 1):
+    try:
         stock = yf.Ticker(arg[0])
-        response = stock.info.get("ask")
-        await ctx.send(response)
-    else:
-        stock = yf.Ticker(arg[0])
-        response = stock.info.get(arg[1])
+        data = stock.info['ask']
+        if (len(arg) == 1):
+            await ctx.send(data)
+        else:
+            response = stock.info.get(arg[1])
+            await ctx.send(response)
+    except IndexError:
+        data = 'null'
+        response = "I can't find your ticker. Sorry :( "
         await ctx.send(response)
 bot.run(TOKEN)


### PR DESCRIPTION
When a user type in a stock ticker that can't be found it will comment to the user 
'I can't find your ticker. Sorry :(  '